### PR TITLE
Add field for checking time interval instead of manual localStorage update

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 /* eslint-disable array-callback-return */
 import "./App.css";
 // import { Notifications } from "react-push-notification";
-import { Button, Col, Input, Row, Radio, Select, Checkbox, Tabs, Modal, Typography, notification, DatePicker } from "antd";
+import { Button, Col, Input, Row, Radio, Select, Checkbox, Tabs, Modal, Typography, notification, DatePicker, InputNumber } from "antd";
 import { CloseCircleOutlined } from "@ant-design/icons";
 import React from "react";
 import Rollbar from "rollbar";
@@ -135,6 +135,7 @@ class App extends React.Component{
       bookingCaptcha: null,
       bookingCenter: null,
       showSuccessModal: false,
+      pollFreq: 45
     };
     if(localStorage.appData){
       try {
@@ -151,6 +152,9 @@ class App extends React.Component{
       state.token = localStorage.token;
       state.isAuthenticated = true;
       state.enableOtp = false;
+    }
+    if(localStorage.pollFreq){
+      state.pollFreq = parseInt(localStorage.pollFreq) / 1000 // to seconds
     }
     
     this.state = state;
@@ -1325,6 +1329,17 @@ class App extends React.Component{
                 </Row>
               </TabPane>
             </Tabs>
+            {!this.state.isWatchingAvailability ? (
+            <Row style={{ marginTop: 5 }}>
+              <h3 style={{ marginTop: 0, marginBottom: 0, marginRight: 10 }}>Checking Time Interval</h3>
+              <InputNumber min={1} defaultValue={this.state.pollFreq} onChange={
+                val => {
+                  this.setState({ pollFreq: val })
+                  localStorage.pollFreq = val * 1000
+                }} />
+              <h4 style={{ marginTop: 2, marginLeft: 10 }}>seconds</h4>
+            </Row>
+            ) : null}
     </div>
   }
   renderBookingPreferences(){

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -9,7 +9,6 @@ const zurl = `https://cdn-api.co-vin.in/api/v2/appointment/sessions/public/calen
 const burl = `https://cdn-api.co-vin.in/api/v2/appointment/schedule`
 const secret = "U2FsdGVkX1+z/4Nr9nta+2DrVJSv7KS6VoQUSQ1ZXYDx/CJUkWxFYG6P3iM/VW+6jLQ9RDQVzp/RcZ8kbT41xw==";
 // const pollFreq = parseInt(localStorage.pollFreq) || 3250;
-const pollFreq = parseInt(localStorage.pollFreq) || 45000;
 export default class CowinApi {
   req(endpoint) {
     let headers = {};
@@ -50,7 +49,7 @@ export default class CowinApi {
           });
       };
       m();
-      this.watcher = setInterval(m, pollFreq);
+      this.watcher = setInterval(m, this.getPollFreq());
     });
   }
 
@@ -71,7 +70,7 @@ export default class CowinApi {
           });
       };
       m();
-      this.watcher = setInterval(m, pollFreq);
+      this.watcher = setInterval(m, this.getPollFreq());
     });
   }
 
@@ -92,7 +91,7 @@ export default class CowinApi {
           });
       };
       m();
-      this.watcher = setInterval(m, pollFreq);
+      this.watcher = setInterval(m, this.getPollFreq());
     });
   }
   distS(url) {
@@ -132,7 +131,7 @@ export default class CowinApi {
           });
       };
       m();
-      this.watcher = setInterval(m, pollFreq);
+      this.watcher = setInterval(m, this.getPollFreq());
     });
   }
   clearWatch() {
@@ -141,6 +140,9 @@ export default class CowinApi {
   }
   clearAuthWatch() {
     clearInterval(this.authWatcher);
+  }
+  getPollFreq() {
+    return parseInt(localStorage.pollFreq) || 45000
   }
   async generateOtp(mobile) {
     return await axios


### PR DESCRIPTION
Instead of manual `localStorage.pollFreq`, I've added a field for setting the value. Also won't require a page refresh for the pollFreq change to take effect, just stop and start tracking again is enough.

![Screenshot_20210623_213342](https://user-images.githubusercontent.com/2305675/123130774-b00a0280-d46a-11eb-8c57-d2886d0118f3.png)